### PR TITLE
Update Actions to work with git repo

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 LABEL name="Pāli-English Recitations build image"
-LABEL version="0.1"
+LABEL version="0.2"
 ARG doomemacs_repo="https://github.com/doomemacs/doomemacs"
 ARG doomemacs_ref="bea3cc161c0a803dcf574f32ee555dccf565a5ce"
 ENV PATH="$PATH:/root/.emacs.d/bin/"
@@ -9,6 +9,7 @@ ENV PATH="$PATH:/root/.emacs.d/bin/"
 RUN \
   apt-get update && \
   apt-get install --no-install-recommends --yes \
+    git \
     locales \
     make \
     zip \
@@ -50,15 +51,11 @@ RUN \
 WORKDIR /root/.emacs.d/
 # hadolint ignore=DL3008
 RUN \
-  apt-get update && \
-  apt-get install --no-install-recommends --yes git && \
   git init && \
   git remote add origin "$doomemacs_repo" && \
   git fetch --depth 1 origin "$doomemacs_ref" && \
   git checkout FETCH_HEAD && \
   org-tangle && \
-  apt-get remove --purge --yes git && \
-  apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,14 +1,13 @@
-FROM debian:bookworm
+# Enough fresh TeXLive and enough old Emacs for org-tangle in Jammy
+FROM ubuntu:jammy
 LABEL name="Pāli-English Recitations build image"
-LABEL version="0.2"
-ARG doomemacs_repo="https://github.com/doomemacs/doomemacs"
-ARG doomemacs_ref="bea3cc161c0a803dcf574f32ee555dccf565a5ce"
-ENV PATH="$PATH:/root/.emacs.d/bin/"
+LABEL version="0.3"
 
 # hadolint ignore=DL3008
 RUN \
   apt-get update && \
   apt-get install --no-install-recommends --yes \
+    ca-certificates \
     git \
     locales \
     make \
@@ -22,6 +21,7 @@ RUN \
 ENV LC_ALL="en_US.UTF-8"
 ENV LANG="en_US.UTF-8"
 
+ARG DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3008
 RUN \
   apt-get update && \
@@ -48,6 +48,9 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+ARG doomemacs_repo="https://github.com/doomemacs/doomemacs"
+ARG doomemacs_ref="d5ccac5d71c819035fa251f01d023b3f94b4fba4"
+ENV PATH="$PATH:/root/.emacs.d/bin/"
 WORKDIR /root/.emacs.d/
 # hadolint ignore=DL3008
 RUN \
@@ -55,7 +58,6 @@ RUN \
   git remote add origin "$doomemacs_repo" && \
   git fetch --depth 1 origin "$doomemacs_ref" && \
   git checkout FETCH_HEAD && \
-  org-tangle && \
-  rm -rf /var/lib/apt/lists/*
+  org-tangle
 
 WORKDIR /root/

--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -11,8 +11,26 @@ jobs:
     runs-on: ubuntu-latest
     container: bergentroll/pali-english-recitations-builder:latest
     steps:
+      - name: install git
+        run: |
+          apt update
+          apt install -y git
       - name: Actions checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      #- name: Stub ref file
+      #  run: |
+      #    mkdir -p .git/ref/
+      #    echo "$GITHUB_REF" > .git/ref/
+      - name: TMP
+        run: |
+          apt update
+          apt install -y tree git
+          git status
+          tree .git
+      - name: Check ref
+        run: cat .git/refs/heads/main
       - name: Build PDF
         run: make pdf2x
       - name: Build EPUB

--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -11,26 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     container: bergentroll/pali-english-recitations-builder:latest
     steps:
-      - name: install git
-        run: |
-          apt update
-          apt install -y git
       - name: Actions checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      #- name: Stub ref file
-      #  run: |
-      #    mkdir -p .git/ref/
-      #    echo "$GITHUB_REF" > .git/ref/
-      - name: TMP
-        run: |
-          apt update
-          apt install -y tree git
-          git status
-          tree .git
       - name: Check ref
-        run: cat .git/refs/heads/main
+        run: |
+          ls --directory .git/
+          cat .git/refs/heads/main
       - name: Build PDF
         run: make pdf2x
       - name: Build EPUB


### PR DESCRIPTION
Fixes #14

Build image changes:
- Switch from Debian Sid to Ubuntu Jammy. It has TeXLive 2021 and Emacs 27.1 which are appropriate and will not be changed in future builds (because Jammy is not rolling).
- Add Git package. With it GitHub Actions provides normal Git repo in a workspace.
- Update doomemacs to the latest commit.